### PR TITLE
dependabot: group action bumps, cap open PRs per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: /lightweight_charts_v5/frontend
     schedule:
       interval: weekly
+    open-pull-requests-limit: 5
     groups:
       npm-minor-patch:
         update-types: [minor, patch]
@@ -25,8 +26,18 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 3
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 3
+    groups:
+      # Deliberately groups majors too, unlike npm-minor-patch above. The
+      # workflows pin actions to major tags (actions/checkout@v7), which float
+      # across minor/patch — so a major bump is the ONLY update Dependabot ever
+      # proposes here, and a minor/patch group would never fire. One weekly PR
+      # for the lot; if a member breaks CI, close it and take them singly.
+      github-actions:
+        patterns: ["*"]


### PR DESCRIPTION
Reduces Dependabot notification noise on this repo.

**Group github-actions updates.** All six action bumps so far arrived as separate PRs and separate emails. They now come as one weekly PR.

The group deliberately includes majors, unlike `npm-minor-patch`. The workflows pin actions to major tags (`actions/checkout@v7`), and those tags float across minor/patch — so a major bump is the only update Dependabot ever proposes here. A minor/patch group would never fire. If a member ever breaks CI, close the group PR and take them individually.

**Cap open PRs per ecosystem** (npm 5, pip 3, actions 3). The unset defaults of 5 each are why turning Dependabot on opened fourteen PRs in one morning.

No change to the React major ignores, which are working as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)